### PR TITLE
Added a NAMESPACE

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,17 @@ How it works
 ------------
 
 Provide a `NAME` for the resource that will be created, each secret should be prefixed with `SK_`, but this will be
-removed when output. Here's what just the output would look like: 
+removed when output. You can optionally provide `NAMESPACE`, but it isn't required. Here's what just the output would
+look like:
 
 ```bash
-$ NAME=test SK_MY_SECRET="my secret" kubesm
+$ NAME=test NAMESPACE=test-namespace SK_MY_SECRET="my secret" kubesm
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: test
+  namespace: "test-namespace"
 type: Opaque
 data:
   MY_SECRET: bXkgc2VjcmV0

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use std::env::{vars, var};
 
 fn main() {
     let secret_name = var("NAME").expect("You must pass NAME in the environment");
-    let secret = Secret::new(secret_name, vars().collect());
+    let secret_namespace = var("NAMESPACE").unwrap_or("default".to_owned());
+    let secret = Secret::new(secret_name, secret_namespace, vars().collect());
     println!("{}", secret.to_yaml());
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use std::env::{vars, var};
 
 fn main() {
     let secret_name = var("NAME").expect("You must pass NAME in the environment");
-    let secret_namespace = var("NAMESPACE").unwrap_or("default".to_owned());
+    let secret_namespace = var("NAMESPACE").ok();
     let secret = Secret::new(secret_name, secret_namespace, vars().collect());
     println!("{}", secret.to_yaml());
 }

--- a/src/secret/mod.rs
+++ b/src/secret/mod.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 #[derive(Serialize, Deserialize, Debug)]
 struct Metadata {
     name: String,
+    namespace: String,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -21,12 +22,13 @@ pub struct Secret {
 }
 
 impl Secret {
-    pub fn new(name: String, source: HashMap<String, String>) -> Secret {
+    pub fn new(name: String, namespace: String, source: HashMap<String, String>) -> Secret {
         Secret {
             api_version: "v1".to_string(),
             kind: "Secret".to_string(),
             metadata: Metadata {
                 name,
+                namespace,
             },
             resource_type: "Opaque".to_string(),
             data: Secret::get_secrets(source),
@@ -54,6 +56,7 @@ mod tests {
     #[test]
     fn e2e() {
         let name = "test-name".to_owned();
+        let namespace = "default".to_owned();
         let source = [
             ("SK_THIS_SHOULD_APPEAR".to_owned(), "win".to_owned()),
             ("THIS_SHOULD_NOT_APPEAR".to_owned(), "fail".to_owned()),
@@ -65,10 +68,11 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: \"test-name\"
+  namespace: default
 type: Opaque
 data:
   THIS_SHOULD_APPEAR: d2lu".to_owned();
 
-        assert_eq!(expected, Secret::new(name, source).to_yaml());
+        assert_eq!(expected, Secret::new(name, namespace, source).to_yaml());
     }
 }

--- a/src/secret/mod.rs
+++ b/src/secret/mod.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 #[derive(Serialize, Deserialize, Debug)]
 struct Metadata {
     name: String,
-    namespace: String,
+    namespace: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -22,7 +22,7 @@ pub struct Secret {
 }
 
 impl Secret {
-    pub fn new(name: String, namespace: String, source: HashMap<String, String>) -> Secret {
+    pub fn new(name: String, namespace: Option<String>, source: HashMap<String, String>) -> Secret {
         Secret {
             api_version: "v1".to_string(),
             kind: "Secret".to_string(),
@@ -56,7 +56,7 @@ mod tests {
     #[test]
     fn e2e() {
         let name = "test-name".to_owned();
-        let namespace = "default".to_owned();
+        let namespace = None;
         let source = [
             ("SK_THIS_SHOULD_APPEAR".to_owned(), "win".to_owned()),
             ("THIS_SHOULD_NOT_APPEAR".to_owned(), "fail".to_owned()),
@@ -68,7 +68,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: \"test-name\"
-  namespace: default
+  namespace: ~
 type: Opaque
 data:
   THIS_SHOULD_APPEAR: d2lu".to_owned();


### PR DESCRIPTION
You can now optionally provide a NAMESPACE environment variable.

Thoughts on how I've added this? Should the default come from `main()`. or should I convert the `Result` to an `Option` and deal with it inside `Secret`?

Adding a feature so would bump this to `1.1.0`.